### PR TITLE
Switch to php-webdriver/webdriver 1.8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php":                ">=7.0",
         "behat/mink":         "~1.7@dev",
-        "facebook/webdriver": "dev-binary-must-be-a-string"
+        "php-webdriver/webdriver": "1.8.2"
     },
     "require-dev": {
         "mink/driver-testsuite": "dev-integration-branch",


### PR DESCRIPTION
The previous `dev-binary-as-string` branch has been merged into php-webdriver and is no longer available.

Switching to the latest release branch to allow dev to continue.