### PR TITLE
clickOnElement should use WebDriverElement::click

### DIFF
--- a/src/WebDriver.php
+++ b/src/WebDriver.php
@@ -773,7 +773,7 @@ class WebDriver extends CoreDriver
 
     private function clickOnElement(WebDriverElement $element)
     {
-        $this->webDriver->action()->click($element)->perform();
+        $element->click();
     }
 
     /**


### PR DESCRIPTION
Clicking on an element is defined in both the W3C specification, and the
JsonWire specification as a command in its own right.

https://www.w3.org/TR/webdriver/#element-click
https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#sessionsessionidelementidclick

It is incorrect to use the mouse action to move to the location and
perform the click as this approach does not wait for the page to unload
before starting the next action.

On some pages this can lead to Mink moving on to the next step before
the page completes the unload, leading to random failures.