### PR TITLE
clickOnElement: Ensure element is in view

### DIFF
--- a/src/WebDriver.php
+++ b/src/WebDriver.php
@@ -774,11 +774,34 @@ class WebDriver extends CoreDriver
         }
     }
 
+    /**
+     * Attempt to ensure that the node is in the viewport.
+     *
+     * @param WebDriverElement $element
+     */
+    private function scrollElementIntoViewIfRequired(WebDriverElement $element)
+    {
+        $js = <<<EOF
+    var node = {{ELEMENT}};
+
+    var rect = node.getBoundingClientRect();
+    var nodeAtRect = document.elementFromPoint(rect.left + (rect.width / 2), rect.top + (rect.height / 2));
+
+    if (!node.contains(nodeAtRect)) {
+        node.scrollIntoView();
+    }
+EOF;
+        $this->executeJsOnElement($element, $js);
+    }
+
     private function clickOnElement(WebDriverElement $element)
     {
         if ($this->browserName === 'firefox') {
-            // TODO: Firefox does not move cursor over an element?
-            $this->webDriver->action()->moveToElement($element)->perform();
+            // TODO: Raise a bug against geckodrvier.
+            // Firefox does not move cursor over an element in breach of https://w3c.github.io/webdriver/#element-click
+            // section 8.Otherwise.
+            $this->scrollElementIntoViewIfRequired($element);
+            $this->mouseOverElement($element);
         }
 
         $element->click();
@@ -829,6 +852,11 @@ class WebDriver extends CoreDriver
     public function mouseOver($xpath)
     {
         $element = $this->findElement($xpath);
+        $this->webDriver->action()->moveToElement($element)->perform();
+    }
+
+    private function mouseOverElement(WebDriverElement $element)
+    {
         $this->webDriver->action()->moveToElement($element)->perform();
     }
 


### PR DESCRIPTION
This code is to work around a bug in geckodriver where the pointer
location is not set before clicking. However, the `moveToElement()`
function only works where the element is in the viewport.

The element must be scrolled into view if it is not already visible
before setting the pointer position.

This issue should also be raised against geckodriver where the bug
actually lies.

Fixes #9