### PR TITLE
Fix capability mapping during test setup

### DIFF
--- a/tests/WebDriverConfig.php
+++ b/tests/WebDriverConfig.php
@@ -49,8 +49,8 @@ class WebDriverConfig extends AbstractConfig
 
         $capabilityMap = [
             'firefox' => FirefoxDriver::PROFILE,
-            'chrome' => ChromeOptions::CAPABILITY_W3C,
-            'msedge' => ChromeOptions::CAPABILITY_W3C,
+            'chrome' => ChromeOptions::CAPABILITY,
+            'msedge' => ChromeOptions::CAPABILITY,
         ];
 
         if (isset($capabilityMap[$browser])) {


### PR DESCRIPTION
The default capability for Chrome is the ChromeOptions::CAPABILITY and
this is converted to CAPABILITY::CAPABILITY_W3C in `toArray()` as
required.

Use of the W3C variant in this manner was causing all arguments and
driver options to be entirely discarded, preventing use of headless
browsers.