### PR TITLE
Reset window handle cache when starting session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Clear the Firefox window handle cache when starting a session
+
 ## [1.0.0] - 2021-01-16
 ### Added
 - Initial implementation as a hard fork from https://github.com/minkphp/MinkSelenium2Driver

--- a/src/WebDriver.php
+++ b/src/WebDriver.php
@@ -266,6 +266,7 @@ class WebDriver extends CoreDriver
                 $this->applyTimeouts();
             }
             $this->rootWindow = $this->webDriver->getWindowHandle();
+            $this->windows = [];
         } catch (\Exception $e) {
             throw new DriverException('Could not open connection: ' . $e->getMessage(), 0, $e);
         }

--- a/tests/Custom/WindowNameTest.php
+++ b/tests/Custom/WindowNameTest.php
@@ -41,4 +41,25 @@ class WindowNameTest extends TestCase
         $el = $webAssert->elementExists('css', '#text');
         $this->assertSame('Popup#1 div text', $el->getText());
     }
+
+    public function testSwitchWindowAfterReset()
+    {
+        $session = $this->getSession();
+        $page = $session->getPage();
+        $webAssert = $this->getAssertSession();
+
+        $session->restart();
+        $session->visit($this->pathTo('/window.html'));
+        $page->clickLink('Popup #1');
+        $session->switchToWindow('popup_1');
+        $el = $webAssert->elementExists('css', '#text');
+        $this->assertSame('Popup#1 div text', $el->getText());
+
+        $session->restart();
+        $session->visit($this->pathTo('/window.html'));
+        $page->clickLink('Popup #2');
+        $session->switchToWindow('popup_2');
+        $el = $webAssert->elementExists('css', '#text');
+        $this->assertSame('Popup#2 div text', $el->getText());
+    }
 }


### PR DESCRIPTION
It seems that Firefox re-uses the window handles between sessions. This
means that the window name cache becomes stale and can potentially point
to the wrong name.

There are a number of solution to this issue, but this is the smallest
change without rewriting the handling completely.

If we can land this and roll a release afterwards that would be great! We went live with the driver yesterday and this issue appeared immediately.