### PR TITLE
Fix: Make SwitchToIframe use id's

### DIFF
--- a/src/WebDriver.php
+++ b/src/WebDriver.php
@@ -412,7 +412,7 @@ class WebDriver extends CoreDriver
     public function switchToIFrame($name = null)
     {
         if ($name) {
-            $element = $this->webDriver->findElement(WebDriverBy::name($name));
+            $element = $this->webDriver->findElement(WebDriverBy::id($name));
             $this->webDriver->switchTo()->frame($element);
         } else {
             $this->webDriver->switchTo()->defaultContent();


### PR DESCRIPTION
The current implementation of switchToIframe is using name instead of id. This behavior is not abiding by the W3C specification, which requests for id to be used.